### PR TITLE
Support building with `base-4.18.*` (GHC 9.6.*)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.6.0.20230111
+            compilerKind: ghc
+            compilerVersion: 9.6.0.20230111
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.4.4
             compilerKind: ghc
             compilerVersion: 9.4.4
@@ -159,7 +164,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           if [ $((HCNUMVER >= 70400)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV" ; else echo "ARG_BENCH=--disable-benchmarks" >> "$GITHUB_ENV" ; fi
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -188,6 +193,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -253,8 +270,10 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package foldable1-classes-compat" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          allow-newer: cassava-0.5.2.0:base
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(foldable1-classes-compat)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,27 +1,39 @@
+{-# LANGUAGE CPP            #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor  #-}
-{-# OPTIONS_GHC -Wall #-}
+
+#if MIN_VERSION_base(4,18,0)
+# define HAS_FOLDABLE1_CONTAINERS MIN_VERSION_containers(0,6,7)
+#else
+# define HAS_FOLDABLE1_CONTAINERS 1
+#endif
+
 module Main (main) where
 
 import Prelude hiding (foldl1, head, last, maximum)
 
 import Control.DeepSeq    (NFData (..))
 import Criterion.Main
-import Data.Foldable      (Foldable)
+import qualified Data.Foldable as F (Foldable)
 import Data.Foldable1
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Semigroup     (Min (..))
+
+#if HAS_FOLDABLE1_CONTAINERS
 import Data.Tree          (Tree (..))
+#endif
 
 input :: NonEmpty Int
 input = 1 :| take 10000000 [2 .. ]
 
+#if HAS_FOLDABLE1_CONTAINERS
 tree :: Tree Int
 tree = go 7 0 where
     go :: Int -> Int -> Tree Int
     go n x
         | n <= 0    = Node x []
         | otherwise = Node x [ go (pred n) (x * 10 + x') | x' <- [0 .. 9] ]
+#endif
 
 main :: IO ()
 main = defaultMain
@@ -51,6 +63,7 @@ main = defaultMain
         , bench "foldlMap1 id min"  $ whnf (foldlMap1 id min) ne
         ]
 
+#if HAS_FOLDABLE1_CONTAINERS
     -- Trees
     , env (return tree) $ \tr -> bgroup "Tree-vanilla"
         [ bench "head" $ whnf head tr
@@ -91,6 +104,7 @@ main = defaultMain
         , bench "foldlMap1' id min" $ whnf (foldlMap1' id min) tr
         , bench "foldlMap1 id min"  $ whnf (foldlMap1 id min) tr
         ]
+#endif
     ]
 
 -------------------------------------------------------------------------------
@@ -99,7 +113,7 @@ main = defaultMain
 
 -- Using foldMap1 only
 newtype NE1 a = NE1 (NonEmpty a)
-  deriving (Functor, Data.Foldable.Foldable)
+  deriving (Functor, F.Foldable)
 
 instance NFData a => NFData (NE1 a) where
     rnf (NE1 xs) = rnf xs
@@ -109,7 +123,7 @@ instance Foldable1 NE1 where
 
 -- Using toNonEmpty
 -- newtype NE2 a = NE2 (NonEmpty a)
---   deriving (Functor, Foldable)
+--   deriving (Functor, F.Foldable)
 --
 -- instance NFData a => NFData (NE2 a) where
 --     rnf (NE2 xs) = rnf xs
@@ -119,7 +133,7 @@ instance Foldable1 NE1 where
 
 -- Using to foldrMap1
 newtype NE3 a = NE3 (NonEmpty a)
-  deriving (Functor, Foldable)
+  deriving (Functor, F.Foldable)
 
 instance NFData a => NFData (NE3 a) where
     rnf (NE3 xs) = rnf xs
@@ -127,13 +141,14 @@ instance NFData a => NFData (NE3 a) where
 instance Foldable1 NE3 where
     foldrMap1 g f (NE3 xs) = foldrMap1 g f xs
 
+#if HAS_FOLDABLE1_CONTAINERS
 -------------------------------------------------------------------------------
 -- Tree variants
 -------------------------------------------------------------------------------
 
 -- Using foldMap1 only
 newtype Tree1 a = Tree1 (Tree a)
-  deriving (Functor, Foldable)
+  deriving (Functor, F.Foldable)
 
 instance NFData a => NFData (Tree1 a) where
     rnf (Tree1 xs) = rnf xs
@@ -143,7 +158,7 @@ instance Foldable1 Tree1 where
 
 -- Using toNonEmpty
 -- newtype Tree2 a = Tree2 (Tree a)
---   deriving (Functor, Foldable)
+--   deriving (Functor, F.Foldable)
 --
 -- instance NFData a => NFData (Tree2 a) where
 --     rnf (Tree2 xs) = rnf xs
@@ -153,10 +168,11 @@ instance Foldable1 Tree1 where
 
 -- Using to foldrMap1
 newtype Tree3 a = Tree3 (Tree a)
-  deriving (Functor, Foldable)
+  deriving (Functor, F.Foldable)
 
 instance NFData a => NFData (Tree3 a) where
     rnf (Tree3 xs) = rnf xs
 
 instance Foldable1 Tree3 where
     foldrMap1 f g (Tree3 xs) = foldrMap1 f g xs
+#endif

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,3 @@
 packages: .
 tests: True
 benchmarks: True
-
-allow-newer: cassava-0.5.2.0:base

--- a/foldable1-classes-compat.cabal
+++ b/foldable1-classes-compat.cabal
@@ -40,6 +40,7 @@ tested-with:
    || ==9.0.2
    || ==9.2.5
    || ==9.4.4
+   || ==9.6.1
 
 -- , GHCJS ==8.4
 
@@ -58,14 +59,17 @@ flag tagged
 
 library
   default-language: Haskell2010
-  hs-source-dirs:   src
   ghc-options:      -Wall
-  exposed-modules:  Data.Foldable1
-  exposed-modules:  Data.Bifoldable1
-  build-depends:
-      base          >=4.3 && <4.18
-    , containers    >=0.4 && <0.7
-    , transformers  >=0.3 && <0.7
+  build-depends:    base >=4.3 && <4.19
+
+  if !impl(ghc >= 9.6)
+    hs-source-dirs: src
+    build-depends:
+        containers    >=0.4 && <0.7
+      , transformers  >=0.3 && <0.7
+    exposed-modules:
+      Data.Foldable1
+      Data.Bifoldable1
 
   if !impl(ghc >=8.6)
     build-depends: base-orphans >=0.8.1 && <0.9
@@ -134,5 +138,5 @@ benchmark bench
       , transformers-compat
 
   build-depends:
-      criterion  >=1.5.6.1 && <1.6
+      criterion  >=1.5.6.1 && <1.7
     , deepseq    >=1.3     && <1.5


### PR DESCRIPTION
When building with `base-4.18.*` or later, we simply re-export `Data.Foldable1` and `Data.Bifoldable1` from `base`.

Fixes #14.