### PR TITLE
CI: Use GHC 9.6.1-alpha3

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230128
+# version: 0.15.20230217
 #
-# REGENDATA ("0.15.20230128",["github","cabal.project"])
+# REGENDATA ("0.15.20230217",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.0.20230111
+          - compiler: ghc-9.6.0.20230210
             compilerKind: ghc
-            compilerVersion: 9.6.0.20230111
+            compilerVersion: 9.6.0.20230210
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.4.4


### PR DESCRIPTION
This is the first alpha release to include a sufficiently recent version of `transformers` that includes `Foldable1` instances.