### PR TITLE
Support MicroHs and modernize cabal file

### DIFF
--- a/foldable1-classes-compat.cabal
+++ b/foldable1-classes-compat.cabal
@@ -1,4 +1,4 @@
-cabal-version: >=1.10
+cabal-version: 2.2
 name:          foldable1-classes-compat
 version:       0.1.2
 synopsis:
@@ -13,7 +13,7 @@ description:
   @Foldable1@ and @Bifoldable1@ classify non-empty data structures that can be
   folded to a summary value.
 
-license:       BSD3
+license:       BSD-3-Clause
 maintainer:    Ryan Scott <ryan.gl.scott@gmail.com>
 author:        Edward Kmett, Oleg Grenrus
 homepage:      https://github.com/haskell-compat/foldable1-classes-compat
@@ -21,7 +21,7 @@ bug-reports:   https://github.com/haskell-compat/foldable1-classes-compat/issues
 category:      Data, Compatibility
 license-file:  LICENSE
 build-type:    Simple
-extra-source-files:
+extra-doc-files:
   CHANGELOG.markdown
   README.markdown
 tested-with:
@@ -59,7 +59,7 @@ library
   ghc-options:      -Wall
   build-depends:    base >=4.9 && <4.22
 
-  if !impl(ghc >= 9.6)
+  if !impl(ghc >= 9.6) && !impl(mhs) -- no Data.Foldable1, Data.Bifoldable1 in base
     hs-source-dirs: src
     build-depends:
         containers    >=0.4 && <0.9
@@ -68,17 +68,17 @@ library
       Data.Foldable1
       Data.Bifoldable1
 
-  if !impl(ghc >=8.6)
-    build-depends: base-orphans >=0.8.1 && <0.10
+    if !impl(ghc >=8.6)
+      build-depends: base-orphans >=0.8.1 && <0.10
 
-  if !impl(ghc >=8.2)
-    build-depends: bifunctor-classes-compat >=0.1 && <0.2
+    if !impl(ghc >=8.2)
+      build-depends: bifunctor-classes-compat >=0.1 && <0.2
 
-  if flag(tagged)
-    build-depends: tagged >=0.4.4 && <1
+    if flag(tagged)
+      build-depends: tagged >=0.4.4 && <1
 
-  if impl(ghc >= 9.0)
-    build-depends: ghc-prim >= 0.7 && <0.14
+    if impl(ghc >= 9.0)
+      build-depends: ghc-prim >= 0.7 && <0.14
 
 test-suite test
   default-language: Haskell2010

--- a/foldable1-classes-compat.cabal
+++ b/foldable1-classes-compat.cabal
@@ -59,14 +59,15 @@ library
   ghc-options:      -Wall
   build-depends:    base >=4.9 && <4.22
 
-  if !impl(ghc >= 9.6) && !impl(mhs) -- no Data.Foldable1, Data.Bifoldable1 in base
-    hs-source-dirs: src
-    build-depends:
-        containers    >=0.4 && <0.9
-      , transformers  >=0.3 && <0.7
-    exposed-modules:
-      Data.Foldable1
-      Data.Bifoldable1
+  if !impl(mhs)
+    if !impl(ghc >= 9.6) -- no Data.Foldable1, Data.Bifoldable1 in base
+      hs-source-dirs: src
+      build-depends:
+          containers    >=0.4 && <0.9
+        , transformers  >=0.3 && <0.7
+      exposed-modules:
+        Data.Foldable1
+        Data.Bifoldable1
 
     if !impl(ghc >=8.6)
       build-depends: base-orphans >=0.8.1 && <0.10


### PR DESCRIPTION
If you don't like `impl(mhs)`, I can change `if !impl(ghc >= 9.6) && !impl(mhs)` to `if impl(ghc <= 9.4)`, but then it might not work for (hypothetical) other Haskell compilers.