### PR TITLE
Move comment to new line

### DIFF
--- a/foldable1-classes-compat.cabal
+++ b/foldable1-classes-compat.cabal
@@ -60,7 +60,8 @@ library
   build-depends:    base >=4.9 && <4.22
 
   if !impl(mhs)
-    if !impl(ghc >= 9.6) -- no Data.Foldable1, Data.Bifoldable1 in base
+    if !impl(ghc >= 9.6)
+      -- no Data.Foldable1, Data.Bifoldable1 in base
       hs-source-dirs: src
       build-depends:
           containers    >=0.4 && <0.9


### PR DESCRIPTION
Apparently, comments at the end of a line aren't really a thing in cabal and they're not allowed in most places. The cabal documentation only mentions that lines whose first non-whitespace characters are `--` are treated as comments. So I'm not sure if it's intentional that it works after an `if`, but MicroCabal doesn't support it, so let's just move the comment to it's own line.

There's no need to publish a revision for this, as MicroCabal currently ignores revisions anyway. We'll just use the git repo for now.

EDIT: It seems like the cabal maintainers consider this a bug: https://github.com/haskell/cabal/issues/9677.